### PR TITLE
Seperate Cauldron and MCPC+ add Liteloader to MODS Correct some Spelling mistakes Add Download to MCPC+ using TOR

### DIFF
--- a/java/FOLIA.md
+++ b/java/FOLIA.md
@@ -35,7 +35,7 @@ This list contains Minecraft Java plugins server softwares based on Folia.
 
 ### [🏔️ DirtyFolia](https://github.com/killerprojecte/Folia)
 - **Version:** 1.19.4-1.20.1
-- **Author:** R00tB33rMan
+- **Author:** killerprojecte
 - **Fork:** CraftBukkit --> Spigot --> Paper --> Folia
 - **Description:** A fork of Folia working to support more bukkit plugins
 - **Plugins:** Paper (Folia)

--- a/java/FOLIA.md
+++ b/java/FOLIA.md
@@ -26,13 +26,6 @@ This list contains Minecraft Java plugins server softwares based on Folia.
 - **Description:** Fork of Folia with more customization options.
 - **Plugins:** Paper (Folia)
   
-### [🌽 Foliocopia](https://github.com/R00tB33rMan/Foliocopia)
-- **Version:** 1.19.4-1.20.1
-- **Author:** R00tB33rMan
-- **Fork:** CraftBukkit --> Spigot --> Paper --> Folia
-- **Description:** Fork of Folia adding CORN REFRENCES!
-- **Plugins:** Paper (Folia)
-
 ### [🏔️ DirtyFolia](https://github.com/killerprojecte/Folia)
 - **Version:** 1.19.4-1.20.1
 - **Author:** killerprojecte

--- a/java/FOLIA.md
+++ b/java/FOLIA.md
@@ -32,3 +32,10 @@ This list contains Minecraft Java plugins server softwares based on Folia.
 - **Fork:** CraftBukkit --> Spigot --> Paper --> Folia
 - **Description:** Fork of Folia adding CORN REFRENCES!
 - **Plugins:** Paper (Folia)
+
+### [🏔️ DirtyFolia](https://github.com/killerprojecte/Folia)
+- **Version:** 1.19.4-1.20.1
+- **Author:** R00tB33rMan
+- **Fork:** CraftBukkit --> Spigot --> Paper --> Folia
+- **Description:** A fork of Folia working to support more bukkit plugins
+- **Plugins:** Paper (Folia)

--- a/java/FOLIA.md
+++ b/java/FOLIA.md
@@ -29,6 +29,6 @@ This list contains Minecraft Java plugins server softwares based on Folia.
 ### [🏔️ DirtyFolia](https://github.com/killerprojecte/Folia)
 - **Version:** 1.19.4-1.20.1
 - **Author:** killerprojecte
-- **Fork:** CraftBukkit --> Spigot --> Paper --> Folia
+- **Fork:** CraftBukkit --> Spigot --> Paper --> Folia --> DirtyFolia
 - **Description:** A fork of Folia working to support more bukkit plugins
 - **Plugins:** Paper (Folia)

--- a/java/FOLIA.md
+++ b/java/FOLIA.md
@@ -25,3 +25,10 @@ This list contains Minecraft Java plugins server softwares based on Folia.
 - **Fork:** CraftBukkit --> Spigot --> Paper --> Folia --> TenseiMC
 - **Description:** Fork of Folia with more customization options.
 - **Plugins:** Paper (Folia)
+  
+### [🌽 Foliocopia](https://github.com/R00tB33rMan/Foliocopia)
+- **Version:** 1.19.4-1.20.1
+- **Author:** R00tB33rMan
+- **Fork:** CraftBukkit --> Spigot --> Paper --> Folia
+- **Description:** Fork of Folia adding CORN REFRENCES!
+- **Plugins:** Paper (Folia)

--- a/java/MODS+PLUGINS.md
+++ b/java/MODS+PLUGINS.md
@@ -182,7 +182,7 @@ This list contains Minecraft Java mods/plugins server softwares.
 
 ### [🚧 MCPC+](https://apocgaming.net/repo/jars/hybrid-servers/MCPC/)
 - **Alternative**: Crucible
-- **Version:** 1.2.5-1.7.2(not all Versions aviable) 
+- **Version:** 1.2.5-1.7.2(not all Versions available) 
 - **Author:** MD-5
 - **Fork:** Forge/CraftBukkit --> MCPC+
 - **Description:** Software that allows the use of Forge Mods and Bukkit plugins on your server (very old, not updated, not recommended).

--- a/java/MODS+PLUGINS.md
+++ b/java/MODS+PLUGINS.md
@@ -182,7 +182,7 @@ This list contains Minecraft Java mods/plugins server softwares.
 
 ### [MCPC+](http://rk2xq6ujanjskx7o2hs5kqfljhdzycn7pfffnwjonunj6woqzpicnpqd.onion)
 - **Alternative**: Crucible
-- **Version:** 1.2.5-1.7.10 
+- **Version:** 1.2.5-1.7.2 
 - **Author:** MD-5
 - **Fork:** Forge/CraftBukkit --> MCPC+
 - **Description:** Software that allows the use of Forge Mods and Bukkit plugins on your server (very old, not updated, not recommended).

--- a/java/MODS+PLUGINS.md
+++ b/java/MODS+PLUGINS.md
@@ -9,7 +9,7 @@ This list contains Minecraft Java mods/plugins server softwares.
 - **Version:** 1.12.2, 1.15.2 (Deprecated), 1.16.5 (Unsupported), 1.18.2, 1.19.3
 - **Author:** MagmaFoundation/Hexeption
 - **Fork:** Forge/Spigot/Paper/Thermos --> Magma
-- **Description:** Software that allows the use of Forge Mods and Bukkit/Spigot/Paper plugins on your server.
+- **Description:** Software that allows the use of Forge Mods and Bukkit/Spigot plugins on your server.
 - **Plugins:** Bukkit, Spigot, Paper
 - **Mods:** Forge
 
@@ -45,10 +45,10 @@ This list contains Minecraft Java mods/plugins server softwares.
 - **Plugins:** Sponge
 - **Mods:** Forge
 
-### [🚩 Mohist Banner](https://github.com/MohistMC/Banner)
+### [🚩 Banner](https://github.com/MohistMC/Banner)
 - **Version:** 1.19.4, 1.20
 - **Author:** MohistMC
-- **Fork:** Fabric/CraftBukkit/Spigot/Paper/Mohist/Arcligth --> Banner
+- **Fork:** Fabric/CraftBukkit/Spigot/Paper/Mohist/Arclight --> Banner
 - **Description:** Fabric Mod that allows the use of Bukkit/Spigot/Paper Plugins.
 - **Plugins:** Bukkit, Spigot, Paper
 - **Mods:** Fabric
@@ -71,6 +71,7 @@ This list contains Minecraft Java mods/plugins server softwares.
 
 # ❌ Inactive Development
 
+
 ### [🌫️ Mist](https://github.com/MinecraftMist/Mist)
 - **Alternative**: Mohist
 - **Version**: 1.16.5
@@ -80,7 +81,7 @@ This list contains Minecraft Java mods/plugins server softwares.
 - **Plugins:** Bukkit, Spigot, Paper
 - **Mods:** Forge
 
-### [🗑 (k)Cauldron/MCPC+](https://sourceforge.net/projects/cauldron-unofficial/)
+### [🗑 (k)Cauldron](https://sourceforge.net/projects/cauldron-unofficial/)
 - **Alternative**: Crucible
 - **Version:** 1.2.5-1.7.10 (not all versions covered)
 - **Author:** Various authors
@@ -178,3 +179,12 @@ This list contains Minecraft Java mods/plugins server softwares.
 - **Description:** Software that allows the use of Forge Mods and Bukkit/Spigot/Paper plugins on your server.
 - **Plugins:** Bukkit, Spigot
 - **Mods:** Forge
+
+### [MCPC+](http://rk2xq6ujanjskx7o2hs5kqfljhdzycn7pfffnwjonunj6woqzpicnpqd.onion)
+- **Alternative**: Crucible
+- **Version:** 1.2.5-1.7.10 
+- **Author:** MD-5
+- **Fork:** Forge/CraftBukkit --> MCPC+
+- **Description:** Software that allows the use of Forge Mods and Bukkit plugins on your server (very old, not updated, not recommended).
+- **Plugins:** Bukkit, Spigot
+- **Mods:** ️ Forge

--- a/java/MODS+PLUGINS.md
+++ b/java/MODS+PLUGINS.md
@@ -182,7 +182,7 @@ This list contains Minecraft Java mods/plugins server softwares.
 
 ### [🚧 MCPC+](https://apocgaming.net/repo/jars/hybrid-servers/MCPC/)
 - **Alternative**: Crucible
-- **Version:** 1.2.5-1.7.2(not all Versions available) 
+- **Version:** 1.2.5-1.7.2 (not all Versions available) 
 - **Author:** MD-5
 - **Fork:** Forge/CraftBukkit --> MCPC+
 - **Description:** Software that allows the use of Forge Mods and Bukkit plugins on your server (very old, not updated, not recommended).

--- a/java/MODS+PLUGINS.md
+++ b/java/MODS+PLUGINS.md
@@ -180,7 +180,7 @@ This list contains Minecraft Java mods/plugins server softwares.
 - **Plugins:** Bukkit, Spigot
 - **Mods:** Forge
 
-### [🚧 MCPC+](http://rk2xq6ujanjskx7o2hs5kqfljhdzycn7pfffnwjonunj6woqzpicnpqd.onion)
+### 🚧 MCPC+
 - **Alternative**: Crucible
 - **Version:** 1.2.5-1.7.2 
 - **Author:** MD-5

--- a/java/MODS+PLUGINS.md
+++ b/java/MODS+PLUGINS.md
@@ -83,7 +83,7 @@ This list contains Minecraft Java mods/plugins server softwares.
 
 ### [🗑 (k)Cauldron](https://sourceforge.net/projects/cauldron-unofficial/)
 - **Alternative**: Crucible
-- **Version:** 1.2.5-1.7.10 (not all versions covered)
+- **Version:** 1.7.10
 - **Author:** Various authors
 - **Fork:** Forge/CraftBukkit --> MCPC+ --> Cauldron --> kCauldron
 - **Description:** Software that allows the use of Forge Mods and Bukkit plugins on your server (very old, not updated, not recommended).

--- a/java/MODS+PLUGINS.md
+++ b/java/MODS+PLUGINS.md
@@ -180,7 +180,7 @@ This list contains Minecraft Java mods/plugins server softwares.
 - **Plugins:** Bukkit, Spigot
 - **Mods:** Forge
 
-### [MCPC+](http://rk2xq6ujanjskx7o2hs5kqfljhdzycn7pfffnwjonunj6woqzpicnpqd.onion)
+### [🚧 MCPC+](http://rk2xq6ujanjskx7o2hs5kqfljhdzycn7pfffnwjonunj6woqzpicnpqd.onion)
 - **Alternative**: Crucible
 - **Version:** 1.2.5-1.7.2 
 - **Author:** MD-5

--- a/java/MODS+PLUGINS.md
+++ b/java/MODS+PLUGINS.md
@@ -180,9 +180,9 @@ This list contains Minecraft Java mods/plugins server softwares.
 - **Plugins:** Bukkit, Spigot
 - **Mods:** Forge
 
-### 🚧 MCPC+
+### [🚧 MCPC+](https://apocgaming.net/repo/jars/hybrid-servers/MCPC/)
 - **Alternative**: Crucible
-- **Version:** 1.2.5-1.7.2 
+- **Version:** 1.2.5-1.7.2(not all Versions aviable) 
 - **Author:** MD-5
 - **Fork:** Forge/CraftBukkit --> MCPC+
 - **Description:** Software that allows the use of Forge Mods and Bukkit plugins on your server (very old, not updated, not recommended).

--- a/java/MODS.md
+++ b/java/MODS.md
@@ -49,5 +49,5 @@ If you're looking for a way to use both **plugins and mods**, checkout [this lis
 - **Version:** 1.5.2 - 1.12.2
 - **Author:** Mumfrey
 - **Fork: Forge** --> Liteloader
-- **Description:** A Mod loader that works ontop of forge and is forge compatable
+- **Description:** A Mod loader that works ontop of forge or on its own and is forge mod compatable
 - **Mods:** Forge/liteloader

--- a/java/MODS.md
+++ b/java/MODS.md
@@ -49,5 +49,5 @@ If you're looking for a way to use both **plugins and mods**, checkout [this lis
 - **Version:** 1.5.2 - 1.12.2
 - **Author:** Mumfrey
 - **Fork: Forge** --> Liteloader
-- **Description:** A Mod loader that works ontop of forge or on its own and is forge mod compatable
-- **Mods:** Forge/liteloader
+- **Description:** A Mod loader that works ontop of Forge or on its own and is Forge mod compatable
+- **Mods:** Forge/Liteloader

--- a/java/MODS.md
+++ b/java/MODS.md
@@ -43,3 +43,11 @@ If you're looking for a way to use both **plugins and mods**, checkout [this lis
 - **Mods:** Forge
 
 # ❌ Inactive Development
+
+### [🐔 LiteLoader](http://www.liteloader.com/explore)
+- **Alternative**: Forge
+- **Version:** 1.5.2 - 1.12.2
+- **Author:** Mumfrey
+- **Fork: Forge** --> Liteloader
+- **Description:** A Mod loader that works ontop of forge and is forge compatable
+- **Mods:** Forge/liteloader

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -186,6 +186,11 @@ This list contains Minecraft Java plugins server softwares.
 - **Fork:** TacoSpigot
 - **Description:** A 1.8.8 TacoSpigot fork focused on SkyBlock servers with entity optimizations, mob stacking, and knockback editing.
 
+### [🍺 BeerSpigot](https://builtbybit.com/threads/%E2%9C%85-breadspigot-%E2%9C%85-skyblock-spigot-optimized-hoppers-entities-redstone-etc-mega-sale-30.475910/)
+- **Version:** 1.8.8
+- **Author:** Diz
+- **Fork:** TacoSpigot
+- **Description:** A 1.8.8 TacoSpigot fork focused on Factions servers with built-in knockback editing and various Factions features.
 
 
 # ❌ Inactive Development

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -154,7 +154,7 @@ This list contains Minecraft Java plugins server softwares.
 - **Version:** 1.19.4
 - **Author:** PlazmaMC
 - **Fork:** CraftBukkit --> Spigot --> Paper --> Pufferfish --> Mirai --> Suki --> Fusion --> Andromeda --> Plazma
-- **Description:** Successor to Fusion and andromeda
+- **Description:** Successor to Fusion and Andromeda.
 - **Plugins:** Bukkit, Spigot, Paper
 
 

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -174,6 +174,13 @@ This list contains Minecraft Java plugins server softwares.
 - **Fork:** TacoSpigot
 - **Description:** Another premium TacoSpigot fork with promises of improved TNT and knockback for PvP and Factions servers.
 
+### [🔥 FlamePaper](https://builtbybit.com/resources/flamepaper-fix-performance-security.19660/)
+- **Version:** 1.8.8
+- **Author:** LinsaFTW
+- **Fork:** Paper
+- **Description:** A 1.8.8 fork of PaperSpigot aiming to improve security and performance for stability.
+
+
 
 
 # ❌ Inactive Development
@@ -371,6 +378,10 @@ This list contains Minecraft Java plugins server softwares.
 - **Fork:** Purpur
 - **Description:** A 1.16.5 Purpur fork with built-in system monitor and optimized block and chunk ticking methods.|
 
-
+### [🌟 Cleanstone](https://github.com/CleanstoneMC/Cleanstone)
+- **Version:** 1.12.2 - 1.14
+- **Author:** LeonMangler
+- **Fork:** -
+- **Description:** A multi-core design server jar coded from the ground up.
 
 

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -180,6 +180,11 @@ This list contains Minecraft Java plugins server softwares.
 - **Fork:** Paper
 - **Description:** A 1.8.8 fork of PaperSpigot aiming to improve security and performance for stability.
 
+### [🍞 BreadSpigot](https://builtbybit.com/threads/%E2%9C%85-breadspigot-%E2%9C%85-skyblock-spigot-optimized-hoppers-entities-redstone-etc-mega-sale-30.475910/)
+- **Version:** 1.8.8
+- **Author:** Diz
+- **Fork:** TacoSpigot
+- **Description:** A 1.8.8 TacoSpigot fork focused on SkyBlock servers with entity optimizations, mob stacking, and knockback editing.
 
 
 

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -180,7 +180,11 @@ This list contains Minecraft Java plugins server softwares.
 - **Fork:** Paper
 - **Description:** A 1.8.8 fork of PaperSpigot aiming to improve security and performance for stability.
 
-
+### [⚡ Plazma](https://github.com/PlazmaMC/Plazma)
+- **Version:** 1.19.4
+- **Author:** PlazmaMC
+- **Fork:** CraftBukkit --> Spigot --> Paper --> Pufferfish --> Mirai --> Suki --> Fusion --> Andromeda --> Plazma
+- **Description:** Successor to Fusion and andromeda
 
 
 # ❌ Inactive Development

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -180,6 +180,11 @@ This list contains Minecraft Java plugins server softwares.
 - **Fork:** Paper
 - **Description:** A 1.8.8 fork of PaperSpigot aiming to improve security and performance for stability.
 
+
+
+
+# ❌ Inactive Development
+
 ### [🍞 BreadSpigot](https://builtbybit.com/threads/%E2%9C%85-breadspigot-%E2%9C%85-skyblock-spigot-optimized-hoppers-entities-redstone-etc-mega-sale-30.475910/)
 - **Version:** 1.8.8
 - **Author:** Diz
@@ -191,9 +196,6 @@ This list contains Minecraft Java plugins server softwares.
 - **Author:** Diz
 - **Fork:** TacoSpigot
 - **Description:** A 1.8.8 TacoSpigot fork focused on Factions servers with built-in knockback editing and various Factions features.
-
-
-# ❌ Inactive Development
 
 ### [🎨 pSpigot](https://scalebound.club/)
 - **Version:** 1.7.10 - 1.8.x

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -143,7 +143,47 @@ This list contains Minecraft Java plugins server softwares.
 - **Description:** Create Minecraft servers with a powerful, stable, and high level JavaScript API.
 - **Plugins:** Flying Squid
 
+### [🦊 FoxSpigot*](https://scalebound.club/)
+- **Version:** 1.8.8
+- **Author:** SB-DEVELOPMENT
+- **Fork:** Spigot
+- **Description:** A fork of Spigot aiming to make PvP servers perform better.
+
+### [🪂 aSpigot*](https://scalebound.club/)
+- **Version:** 1.7.10
+- **Author:** SB-DEVELOPMENT
+- **Fork:** Paper
+- **Description:** A premium 1.7.10 Paper fork with custom knockback editing, togglable mob AI, and features for HCF servers.
+
+### [🔗 wSpigot*](https://scalebound.club/)
+- **Version:** 1.7.10 - 1.8.x
+- **Author:** SB-DEVELOPMENT
+- **Fork:** TacoSpigot
+- **Description:** Another premium TacoSpigot fork with improved TNT and knockback for PvP and Factions servers.
+
+### [🔥 KSpigot](https://scalebound.club/)
+- **Version:** 1.12.2
+- **Author:** SB-DEVELOPMENT
+- **Fork:** Paper
+- **Description:** A performance server jar built off of Paper with custom knockback and entity pathing.
+- **Status:** Currently Active
+
+### [🔵 mSpigot*](https://scalebound.club/)
+- **Version:** 1.8.8
+- **Author:** SB-DEVELOPMENT
+- **Fork:** TacoSpigot
+- **Description:** Another premium TacoSpigot fork with promises of improved TNT and knockback for PvP and Factions servers.
+
+
+
 # ❌ Inactive Development
+
+### [🎨 pSpigot](https://scalebound.club/)
+- **Version:** 1.7.10 - 1.8.x
+- **Author:** SB-DEVELOPMENT
+- **Fork:** TacoSpigot
+- **Description:** A 1.7.10 - 1.8.x TacoSpigot fork with custom knockback editing and options like toggleable mob AI.
+
 ### [🦈 Sharkur](https://github.com/SharkurMC/Sharkur)
 - **Version:** 1.19 - 1.19.1
 - **Author:** SharkurMC
@@ -324,3 +364,13 @@ This list contains Minecraft Java plugins server softwares.
 - **Fork:** hMod --> CanaryMod
 - **Description:** A fork of hMod.
 - **Plugins:** hMod
+
+### [🚀 APOLLO16](https://builtbybit.com/resources/apollo16-most-optimized-1-16-5-fork-on-mcm.16271/)
+- **Version:** 1.16.5
+- **Author:** MeerBiene
+- **Fork:** Purpur
+- **Description:** A 1.16.5 Purpur fork with built-in system monitor and optimized block and chunk ticking methods.|
+
+
+
+

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -146,38 +146,38 @@ This list contains Minecraft Java plugins server softwares.
 ### [🦊 FoxSpigot*](https://scalebound.club/)
 - **Version:** 1.8.8
 - **Author:** SB-DEVELOPMENT
-- **Fork:** Spigot
+- **Fork:** CraftBukkit --> Spigot --> FoxSpigot
 - **Description:** A fork of Spigot aiming to make PvP servers perform better.
 
 ### [🪂 aSpigot*](https://scalebound.club/)
 - **Version:** 1.7.10
 - **Author:** SB-DEVELOPMENT
-- **Fork:** Paper
+- **Fork:**  CraftBukkit --> Spigot --> Paper --> aSpigot
 - **Description:** A premium 1.7.10 Paper fork with custom knockback editing, togglable mob AI, and features for HCF servers.
 
 ### [🔗 wSpigot*](https://scalebound.club/)
 - **Version:** 1.7.10 - 1.8.x
 - **Author:** SB-DEVELOPMENT
-- **Fork:** TacoSpigot
+- **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> wSpigot
 - **Description:** Another premium TacoSpigot fork with improved TNT and knockback for PvP and Factions servers.
 
-### [🔥 KSpigot](https://scalebound.club/)
+### [🔥 kSpigot](https://scalebound.club/)
 - **Version:** 1.12.2
 - **Author:** SB-DEVELOPMENT
-- **Fork:** Paper
+- **Fork:** CraftBukkit --> Spigot --> Paper --> kSpigot
 - **Description:** A performance server jar built off of Paper with custom knockback and entity pathing.
 - **Status:** Currently Active
 
 ### [🔵 mSpigot*](https://scalebound.club/)
 - **Version:** 1.8.8
 - **Author:** SB-DEVELOPMENT
-- **Fork:** TacoSpigot
+- **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> mSpigot
 - **Description:** Another premium TacoSpigot fork with promises of improved TNT and knockback for PvP and Factions servers.
 
 ### [🔥 FlamePaper](https://builtbybit.com/resources/flamepaper-fix-performance-security.19660/)
 - **Version:** 1.8.8
 - **Author:** LinsaFTW
-- **Fork:** Paper
+- **Fork:** CraftBukkit --> Spigot --> Paper --> FlamePaper
 - **Description:** A 1.8.8 fork of PaperSpigot aiming to improve security and performance for stability.
 
 ### [⚡ Plazma](https://github.com/PlazmaMC/Plazma)
@@ -192,19 +192,19 @@ This list contains Minecraft Java plugins server softwares.
 ### [🍞 BreadSpigot](https://builtbybit.com/threads/%E2%9C%85-breadspigot-%E2%9C%85-skyblock-spigot-optimized-hoppers-entities-redstone-etc-mega-sale-30.475910/)
 - **Version:** 1.8.8
 - **Author:** Diz
-- **Fork:** TacoSpigot
+- **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> BreadSpigot
 - **Description:** A 1.8.8 TacoSpigot fork focused on SkyBlock servers with entity optimizations, mob stacking, and knockback editing.
 
 ### [🍺 BeerSpigot](https://builtbybit.com/threads/%E2%9C%85-breadspigot-%E2%9C%85-skyblock-spigot-optimized-hoppers-entities-redstone-etc-mega-sale-30.475910/)
 - **Version:** 1.8.8
 - **Author:** Diz
-- **Fork:** TacoSpigot
+- **Fork:**  CraftBukkit --> Spigot --> Paper --> TacoSpigot --> BeerSpigot
 - **Description:** A 1.8.8 TacoSpigot fork focused on Factions servers with built-in knockback editing and various Factions features.
 
 ### [🎨 pSpigot](https://scalebound.club/)
 - **Version:** 1.7.10 - 1.8.x
 - **Author:** SB-DEVELOPMENT
-- **Fork:** TacoSpigot
+- **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> pSpigot
 - **Description:** A 1.7.10 - 1.8.x TacoSpigot fork with custom knockback editing and options like toggleable mob AI.
 
 ### [🦈 Sharkur](https://github.com/SharkurMC/Sharkur)
@@ -391,7 +391,7 @@ This list contains Minecraft Java plugins server softwares.
 ### [🚀 APOLLO16](https://builtbybit.com/resources/apollo16-most-optimized-1-16-5-fork-on-mcm.16271/)
 - **Version:** 1.16.5
 - **Author:** MeerBiene
-- **Fork:** Purpur
+- **Fork:** CraftBukkit --> Spigot --> Paper --> Pufferfish --> Purpur --> APOLLO16
 - **Description:** A 1.16.5 Purpur fork with built-in system monitor and optimized block and chunk ticking methods.|
 
 ### [🌟 Cleanstone](https://github.com/CleanstoneMC/Cleanstone)

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -142,43 +142,8 @@ This list contains Minecraft Java plugins server softwares.
 - **Fork:** -
 - **Description:** Create Minecraft servers with a powerful, stable, and high level JavaScript API.
 - **Plugins:** Flying Squid
-
-### [🦊 FoxSpigot*](https://scalebound.club/)
-- **Version:** 1.8.8
-- **Author:** SB-DEVELOPMENT
-- **Fork:** CraftBukkit --> Spigot --> FoxSpigot
-- **Description:** A fork of Spigot aiming to make PvP servers perform better.
-- **Plugins:** Bukkit, Spigot
   
-### [🪂 aSpigot*](https://scalebound.club/)
-- **Version:** 1.7.10
-- **Author:** SB-DEVELOPMENT
-- **Fork:**  CraftBukkit --> Spigot --> Paper --> aSpigot
-- **Description:** A premium 1.7.10 Paper fork with custom knockback editing, togglable mob AI, and features for HCF servers.
-- **Plugins:** Bukkit, Spigot, Paper
-  
-### [🔗 wSpigot*](https://scalebound.club/)
-- **Version:** 1.7.10 - 1.8.x
-- **Author:** SB-DEVELOPMENT
-- **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> wSpigot
-- **Description:** Another premium TacoSpigot fork with improved TNT and knockback for PvP and Factions servers.
-- **Plugins:** Bukkit, Spigot, Paper
-  
-### [🔥 kSpigot](https://scalebound.club/)
-- **Version:** 1.12.2
-- **Author:** SB-DEVELOPMENT
-- **Fork:** CraftBukkit --> Spigot --> Paper --> kSpigot
-- **Description:** A performance server jar built off of Paper with custom knockback and entity pathing.
-- **Plugins:** Bukkit, Spigot, Paper
-
-### [🔵 mSpigot*](https://scalebound.club/)
-- **Version:** 1.8.8
-- **Author:** SB-DEVELOPMENT
-- **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> mSpigot
-- **Description:** Another premium TacoSpigot fork with promises of improved TNT and knockback for PvP and Factions servers.
-- **Plugins:** Bukkit, Spigot, Paper
-  
-### [🔥 FlamePaper](https://builtbybit.com/resources/flamepaper-fix-performance-security.19660/)
+### [🔥 FlamePaper](https://github.com/galgotuberz/FlamePaper)
 - **Version:** 1.8.8
 - **Author:** LinsaFTW
 - **Fork:** CraftBukkit --> Spigot --> Paper --> FlamePaper
@@ -194,27 +159,6 @@ This list contains Minecraft Java plugins server softwares.
 
 
 # ❌ Inactive Development
-
-### [🍞 BreadSpigot](https://builtbybit.com/threads/%E2%9C%85-breadspigot-%E2%9C%85-skyblock-spigot-optimized-hoppers-entities-redstone-etc-mega-sale-30.475910/)
-- **Version:** 1.8.8
-- **Author:** Diz
-- **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> BreadSpigot
-- **Description:** A 1.8.8 TacoSpigot fork focused on SkyBlock servers with entity optimizations, mob stacking, and knockback editing.
-- **Plugins:** Bukkit, Spigot, Paper
-  
-### [🍺 BeerSpigot](https://builtbybit.com/threads/%E2%9C%85-breadspigot-%E2%9C%85-skyblock-spigot-optimized-hoppers-entities-redstone-etc-mega-sale-30.475910/)
-- **Version:** 1.8.8
-- **Author:** Diz
-- **Fork:**  CraftBukkit --> Spigot --> Paper --> TacoSpigot --> BeerSpigot
-- **Description:** A 1.8.8 TacoSpigot fork focused on Factions servers with built-in knockback editing and various Factions features.
-- **Plugins:** Bukkit, Spigot, Paper
-  
-### [🎨 pSpigot](https://scalebound.club/)
-- **Version:** 1.7.10 - 1.8.x
-- **Author:** SB-DEVELOPMENT
-- **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> pSpigot
-- **Description:** A 1.7.10 - 1.8.x TacoSpigot fork with custom knockback editing and options like toggleable mob AI.
-- **Plugins:** Bukkit, Spigot, Paper
   
 ### [🦈 Sharkur](https://github.com/SharkurMC/Sharkur)
 - **Version:** 1.19 - 1.19.1
@@ -397,12 +341,6 @@ This list contains Minecraft Java plugins server softwares.
 - **Description:** A fork of hMod.
 - **Plugins:** hMod
 
-### [🚀 APOLLO16](https://builtbybit.com/resources/apollo16-most-optimized-1-16-5-fork-on-mcm.16271/)
-- **Version:** 1.16.5
-- **Author:** MeerBiene
-- **Fork:** CraftBukkit --> Spigot --> Paper --> Pufferfish --> Purpur --> APOLLO16
-- **Description:** A 1.16.5 Purpur fork with built-in system monitor and optimized block and chunk ticking methods.|
-- **Plugins:** Bukkit, Spigot, Paper
   
 
 

--- a/java/PLUGINS.md
+++ b/java/PLUGINS.md
@@ -148,43 +148,49 @@ This list contains Minecraft Java plugins server softwares.
 - **Author:** SB-DEVELOPMENT
 - **Fork:** CraftBukkit --> Spigot --> FoxSpigot
 - **Description:** A fork of Spigot aiming to make PvP servers perform better.
-
+- **Plugins:** Bukkit, Spigot
+  
 ### [🪂 aSpigot*](https://scalebound.club/)
 - **Version:** 1.7.10
 - **Author:** SB-DEVELOPMENT
 - **Fork:**  CraftBukkit --> Spigot --> Paper --> aSpigot
 - **Description:** A premium 1.7.10 Paper fork with custom knockback editing, togglable mob AI, and features for HCF servers.
-
+- **Plugins:** Bukkit, Spigot, Paper
+  
 ### [🔗 wSpigot*](https://scalebound.club/)
 - **Version:** 1.7.10 - 1.8.x
 - **Author:** SB-DEVELOPMENT
 - **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> wSpigot
 - **Description:** Another premium TacoSpigot fork with improved TNT and knockback for PvP and Factions servers.
-
+- **Plugins:** Bukkit, Spigot, Paper
+  
 ### [🔥 kSpigot](https://scalebound.club/)
 - **Version:** 1.12.2
 - **Author:** SB-DEVELOPMENT
 - **Fork:** CraftBukkit --> Spigot --> Paper --> kSpigot
 - **Description:** A performance server jar built off of Paper with custom knockback and entity pathing.
-- **Status:** Currently Active
+- **Plugins:** Bukkit, Spigot, Paper
 
 ### [🔵 mSpigot*](https://scalebound.club/)
 - **Version:** 1.8.8
 - **Author:** SB-DEVELOPMENT
 - **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> mSpigot
 - **Description:** Another premium TacoSpigot fork with promises of improved TNT and knockback for PvP and Factions servers.
-
+- **Plugins:** Bukkit, Spigot, Paper
+  
 ### [🔥 FlamePaper](https://builtbybit.com/resources/flamepaper-fix-performance-security.19660/)
 - **Version:** 1.8.8
 - **Author:** LinsaFTW
 - **Fork:** CraftBukkit --> Spigot --> Paper --> FlamePaper
 - **Description:** A 1.8.8 fork of PaperSpigot aiming to improve security and performance for stability.
-
+- **Plugins:** Bukkit, Spigot, Paper
+  
 ### [⚡ Plazma](https://github.com/PlazmaMC/Plazma)
 - **Version:** 1.19.4
 - **Author:** PlazmaMC
 - **Fork:** CraftBukkit --> Spigot --> Paper --> Pufferfish --> Mirai --> Suki --> Fusion --> Andromeda --> Plazma
 - **Description:** Successor to Fusion and andromeda
+- **Plugins:** Bukkit, Spigot, Paper
 
 
 # ❌ Inactive Development
@@ -194,19 +200,22 @@ This list contains Minecraft Java plugins server softwares.
 - **Author:** Diz
 - **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> BreadSpigot
 - **Description:** A 1.8.8 TacoSpigot fork focused on SkyBlock servers with entity optimizations, mob stacking, and knockback editing.
-
+- **Plugins:** Bukkit, Spigot, Paper
+  
 ### [🍺 BeerSpigot](https://builtbybit.com/threads/%E2%9C%85-breadspigot-%E2%9C%85-skyblock-spigot-optimized-hoppers-entities-redstone-etc-mega-sale-30.475910/)
 - **Version:** 1.8.8
 - **Author:** Diz
 - **Fork:**  CraftBukkit --> Spigot --> Paper --> TacoSpigot --> BeerSpigot
 - **Description:** A 1.8.8 TacoSpigot fork focused on Factions servers with built-in knockback editing and various Factions features.
-
+- **Plugins:** Bukkit, Spigot, Paper
+  
 ### [🎨 pSpigot](https://scalebound.club/)
 - **Version:** 1.7.10 - 1.8.x
 - **Author:** SB-DEVELOPMENT
 - **Fork:** CraftBukkit --> Spigot --> Paper --> TacoSpigot --> pSpigot
 - **Description:** A 1.7.10 - 1.8.x TacoSpigot fork with custom knockback editing and options like toggleable mob AI.
-
+- **Plugins:** Bukkit, Spigot, Paper
+  
 ### [🦈 Sharkur](https://github.com/SharkurMC/Sharkur)
 - **Version:** 1.19 - 1.19.1
 - **Author:** SharkurMC
@@ -393,11 +402,7 @@ This list contains Minecraft Java plugins server softwares.
 - **Author:** MeerBiene
 - **Fork:** CraftBukkit --> Spigot --> Paper --> Pufferfish --> Purpur --> APOLLO16
 - **Description:** A 1.16.5 Purpur fork with built-in system monitor and optimized block and chunk ticking methods.|
-
-### [🌟 Cleanstone](https://github.com/CleanstoneMC/Cleanstone)
-- **Version:** 1.12.2 - 1.14
-- **Author:** LeonMangler
-- **Fork:** -
-- **Description:** A multi-core design server jar coded from the ground up.
+- **Plugins:** Bukkit, Spigot, Paper
+  
 
 

--- a/java/VANILLA.md
+++ b/java/VANILLA.md
@@ -57,3 +57,9 @@ This list contains Minecraft Java vanilla server softwares.
 - **Author:** BizzareCake
 - **Fork:** -
 - **Description:** A custom implementation of a Minecraft server striving to be fast, customizable and easy to use.
+  
+### [🌟 Cleanstone](https://github.com/CleanstoneMC/Cleanstone)
+- **Version:** 1.12.2 - 1.14
+- **Author:** LeonMangler
+- **Fork:** -
+- **Description:** A multi-core design server jar coded from the ground up.


### PR DESCRIPTION
Seperating Cauldron And MCPC+ as MCPC+ was  MADE by MD-5 at the time, and deserves it's own category, Also added a link to download the files hosted on tor,Fixed some spelling errors and removed paper plugins from the description of magma as only 1.12.2 can run paper plugins completely.